### PR TITLE
Set cache-control and expires headers to improve browser caching.

### DIFF
--- a/lib/middleman-s3_sync.rb
+++ b/lib/middleman-s3_sync.rb
@@ -13,6 +13,9 @@ end
 module Middleman
   module S3Sync
     class << self
+      LONG_TIME = 315360000   # 10 years
+      DONT_CACHE = ['html']   # types of files to exclude from browser cache
+
       def sync
         puts "Gathering local files."
 
@@ -65,12 +68,21 @@ module Middleman
               file.save
             else
               puts "Creating #{f}"
-              file = bucket.files.create({
+              file_hash = {
                 :key => f,
                 :body => File.open("#{options.build_dir}/#{f}"),
                 :public => true,
                 :acl => 'public-read'
-              })
+              }
+              # Add cache-control headers
+              ext = File.extname(f)[1..-1]
+              unless DONT_CACHE.include? ext
+                file_hash.merge!({
+                  :cache_control => "public, max-age=#{LONG_TIME}",
+                  :expires => CGI.rfc1123_date(Time.now + LONG_TIME)
+                })
+              end
+              file = bucket.files.create(file_hash)
             end
           end
         else


### PR DESCRIPTION
I'm assuming most assets deployed with Middleman will use an asset hash. So setting expiration for 1 year should be safe. This cache expiration is based on the asset_sync gem's cache headers.
