### PR TITLE
Correct use of s3_resource with a caching policy

### DIFF
--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -26,7 +26,7 @@ module Middleman
 
         if caching_policy
           attributes[:cache_control] = caching_policy.cache_control
-          attributes[:expires] = caching_control.expires
+          attributes[:expires] = caching_policy.expires
         end
 
         if options.prefer_gzip && gzipped


### PR DESCRIPTION
This makes sure we're using the correct variable of `s3_resource` if you have a caching policy in place. The previous variable of `file` doesn't exist anymore due to the recent re-factor.
