### PR TITLE
Fixed typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following defaults apply to the configuration items:
 
 | Setting                    | Default                            |
 | -----------------          | ----------------------------       |
-| aws_access_key_id          | ```ENV['AWS_ACCESS_KEY_ID```       |
+| aws_access_key_id          | ```ENV['AWS_ACCESS_KEY_ID']```       |
 | aws_secret_access_key      | ```ENV['AWS_SECRET_ACCESS_KEY']``` |
 | delete                     | ```true```                         |
 | after_build                | ```false```                        |


### PR DESCRIPTION
Fixed a small but important typo in the documentation.
