### PR TITLE
Add support for path_style option

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -40,7 +40,8 @@ module Middleman
           :provider => 'AWS',
           :aws_access_key_id => s3_sync_options.aws_access_key_id,
           :aws_secret_access_key => s3_sync_options.aws_secret_access_key,
-          :region => s3_sync_options.region
+          :region => s3_sync_options.region,
+          :path_style => s3_sync_options.path_style
         })
       end
 

--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -14,6 +14,7 @@ module Middleman
         :force,
         :prefer_gzip,
         :reduced_redundancy_storage,
+        :path_style,
         :verbose
 
       def initialize
@@ -55,6 +56,10 @@ module Middleman
 
       def prefer_gzip
         (@prefer_gzip.nil? ? true : @prefer_gzip)
+      end
+
+      def path_style
+        (@path_style.nil? ? false : @path_style)
       end
 
       # Read config options from an IO stream and set them on `self`. Defaults


### PR DESCRIPTION
Dots in bucket name will trigger an SSL mismatch error.
Fog has a path_style option to prevent this error.
You can now add this option in your config file to pass it to Fog: `s3_sync.path_style = true`
