### PR TITLE
Resources can be encrypted on sync

### DIFF
--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -9,6 +9,7 @@ module Middleman
         :aws_secret_access_key,
         :after_build,
         :delete,
+        :encryption,
         :existing_remote_file,
         :build_dir,
         :force,
@@ -44,6 +45,10 @@ module Middleman
 
       def aws_secret_access_key
         @aws_secret_access_key || ENV['AWS_SECRET_ACCESS_KEY']
+      end
+
+      def encryption
+        @encryption.nil? ? false : @encryption
       end
 
       def delete

--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -40,6 +40,10 @@ module Middleman
           attributes[:storage_class] = 'REDUCED_REDUNDANCY'
         end
 
+        if options.encryption
+          attributes[:encryption] = 'AES256'
+        end
+
         attributes
       end
       alias :attributes :to_h
@@ -69,6 +73,10 @@ module Middleman
 
         if options.reduced_redundancy_storage
           s3_resource.storage_class = 'REDUCED_REDUNDANCY'
+        end
+
+        if options.encryption
+          s3_resource.encryption = 'AES256'
         end
 
         s3_resource.save


### PR DESCRIPTION
This option allows you to specify that you wish to encrypt resources.  See http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html for details.
