### PR TITLE
Avoid HEAD requests

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -46,7 +46,7 @@ module Middleman
       def resources
         @resources ||= paths.pmap(32) do |p|
           progress_bar.increment
-          S3Sync::Resource.new(p)
+          S3Sync::Resource.new(p, bucket_files.find { |f| f.key == p }).tap(&:status)
         end
       end
 
@@ -75,7 +75,15 @@ module Middleman
       end
 
       def remote_paths
-        @remote_paths ||= bucket.files.map{ |f| f.key }
+        @remote_paths ||= bucket_files.map(&:key)
+      end
+      
+      def bucket_files
+        @bucket_files ||= [].tap { |files|
+          bucket.files.each { |f|
+            files << f
+          }
+        }
       end
 
       def create_resources


### PR DESCRIPTION
The output from the directory list is sufficient for determining a course of action, since it includes all keys and ETags for every object in question. Eliminating the HEAD-per-object request reduces the total number of requests by several orders of magnitude.
