### PR TITLE
Delete files that became directories

### DIFF
--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -139,7 +139,11 @@ module Middleman
 
       def status
         @status ||= if directory?
-                      :ignored
+                      if remote?
+                        :deleted
+                      else
+                        :ignored
+                      end
                     elsif local? && remote?
                       if content_md5 != remote_md5
                         :updated


### PR DESCRIPTION
If `/foo` is created, uploaded to S3, then deleted and replaced by a directory containing `/foo/index.html`, `/foo` should be deleted on S3.
