### PR TITLE
Populate metadata before detecting redirects.

### DIFF
--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -198,7 +198,7 @@ module Middleman
       end
 
       def redirect?
-        s3_resource.metadata.has_key?('x-amz-website-redirect-location')
+        full_s3_resource.metadata.has_key?('x-amz-website-redirect-location')
       end
 
       def directory?


### PR DESCRIPTION
I've found that `s3_resource.metadata` doesn't include the `x-amz-website-redirect-location` header, causing redirects to be deleted.
