### PR TITLE
Exposing a hook to other extensions

### DIFF
--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -12,6 +12,8 @@ module Middleman
 
         app.send :include, Helpers
 
+        app.define_hook :after_s3_sync
+
         app.after_configuration do |config|
 
           # Define the after_build step after during configuration so

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -15,6 +15,8 @@ module Middleman
       include Status
 
       def sync
+        @app = ::Middleman::Application.server.inst
+
         unless work_to_be_done?
           say_status "\nAll S3 files are up to date."
           return
@@ -28,6 +30,11 @@ module Middleman
         create_resources
         update_resources
         delete_resources
+
+        @app.run_hook :after_s3_sync, ignored: files_to_ignore.map(&:path),
+                                      created: files_to_create.map(&:path),
+                                      updated: files_to_update.map(&:path),
+                                      deleted: files_to_delete.map(&:path)
       end
 
       def bucket


### PR DESCRIPTION
What are your thoughts on providing a post-sync hook? I'd like to rig up [Middleman CloudFront](https://github.com/andrusha/middleman-cloudfront) to automatically invalidate whatever has been updated, a la:

``` ruby
after_s3_sync do |destination_paths|
  invalidate destination_paths[:updated]
end
```

Is this a good way to go?
