### PR TITLE
.s3_sync file can override any of the options

### DIFF
--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -1,7 +1,7 @@
 module Middleman
   module S3Sync
     class Options
-      attr_accessor \
+      OPTIONS = [
         :prefix,
         :acl,
         :bucket,
@@ -19,6 +19,8 @@ module Middleman
         :path_style,
         :version_bucket,
         :verbose
+      ]
+      attr_accessor *OPTIONS
 
       def initialize
         # read config from .s3_sync on initialization
@@ -105,10 +107,11 @@ module Middleman
           io = File.open(config_file_path, "r")
         end
 
-        config = YAML.load(io)
+        config = YAML.load(io).symbolize_keys
 
-        self.aws_access_key_id = config["aws_access_key_id"] if config["aws_access_key_id"]
-        self.aws_secret_access_key = config["aws_secret_access_key"] if config["aws_secret_access_key"]
+        OPTIONS.each do |config_option|
+          self.send("#{config_option}=".to_sym, config[config_option]) if config[config_option]
+        end
       end
 
       protected

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -105,7 +105,8 @@ describe Middleman::S3Sync::Options do
   context "#read_config" do
     let(:aws_access_key_id) { "foo" }
     let(:aws_secret_access_key) { "bar" }
-    let(:config) { { "aws_access_key_id" => aws_access_key_id, "aws_secret_access_key" => aws_secret_access_key } }
+    let(:bucket) { "baz" }
+    let(:config) { { "aws_access_key_id" => aws_access_key_id, "aws_secret_access_key" => aws_secret_access_key, "bucket" => bucket } }
     let(:file) { StringIO.new(YAML.dump(config)) }
 
     before do
@@ -114,5 +115,6 @@ describe Middleman::S3Sync::Options do
 
     its(:aws_access_key_id) { should eq(aws_access_key_id) }
     its(:aws_secret_access_key) { should eq(aws_secret_access_key) }
+    its(:bucket) { should eq(bucket) }
   end
 end


### PR DESCRIPTION
Here's the pull request of the issue https://github.com/fredjean/middleman-s3_sync/issues/58
I only added test for bucket, but you can set any option.
