### PR TITLE
Remove leading forward slash from prefix example in README, fixes #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ option in the config block:
 ```ruby
 activate :s3_sync do |s3_sync|
   # ...
-  s3_sync.prefix = '/prefix'
+  s3_sync.prefix = 'prefix'
 end
 ```
 


### PR DESCRIPTION
The leading forward slash was preventing me from writing to the specified folder in my s3 bucket. Related: #74 