### PR TITLE
Optimise syncing when files are not deleted

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -99,7 +99,11 @@ module Middleman
       end
 
       def remote_paths
-        @remote_paths ||= bucket_files.map(&:key)
+        @remote_paths ||= if s3_sync_options.delete
+                            bucket_files.map(&:key)
+                          else
+                            []
+                          end
       end
 
       def bucket_files


### PR DESCRIPTION
When delete option is set to false, existing files in S3 can be ignored. This makes syncing significantly faster when there are a lot of files.

The implementation is easy by ignoring `remote_files` in paths, but then access to `bucket` and `bucket_files` can lead to race condition. To solve this, I've synchronised calls to these methods.