### PR TITLE
Depend on fog-aws

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws/storage'
 require 'pmap'
 require 'digest/md5'
 require 'middleman/s3_sync/version'
@@ -53,8 +53,7 @@ module Middleman
       end
 
       def connection
-        @connection ||= Fog::Storage.new({
-          :provider => 'AWS',
+        @connection ||= Fog::Storage::AWS.new({
           :aws_access_key_id => s3_sync_options.aws_access_key_id,
           :aws_secret_access_key => s3_sync_options.aws_secret_access_key,
           :region => s3_sync_options.region,

--- a/middleman-s3_sync.gemspec
+++ b/middleman-s3_sync.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'middleman-core', '>= 3.0.0'
   gem.add_runtime_dependency 'unf'
-  gem.add_runtime_dependency 'fog', '>= 1.25.0'
+  gem.add_runtime_dependency 'fog-aws', '>= 0.1.1'
   gem.add_runtime_dependency 'map'
   gem.add_runtime_dependency 'pmap'
   gem.add_runtime_dependency 'ruby-progressbar'


### PR DESCRIPTION
The extracted fog-aws gem is much smaller than the full fog library. Since middleman-s3_sync only deals with S3, it'd make sense to use the provider-specific gem.