### PR TITLE
Fix fog-aws require

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -1,4 +1,4 @@
-require 'fog/aws/storage'
+require 'fog/aws'
 require 'pmap'
 require 'digest/md5'
 require 'middleman/s3_sync/version'


### PR DESCRIPTION
`Fog::AWS:Storage` need some libs which are required only in `fog/aws`.
So we need to require the whole `fog/aws`.

Also fix #82.

FIY: Not detected by the test suite because of the `Fog.mock!`.