### PR TITLE
Add IAM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ map to the following values:
 The environment is used when the credentials are not set in the activate
 method or passed through the ```.s3_sync``` configuration file.
 
+#### Through IAM role
+
+Alternatively, if you are running builds on EC2 instance which has approrpiate IAM role, then you don't need to think about specifying credentials at all – they will be pulled from AWS metadata server.
+
 ### IAM Policy
 
 Here's a sample IAM policy that will allow a user to update the site

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -58,12 +58,22 @@ module Middleman
       end
 
       def connection
-        @connection ||= Fog::Storage::AWS.new({
-          :aws_access_key_id => s3_sync_options.aws_access_key_id,
-          :aws_secret_access_key => s3_sync_options.aws_secret_access_key,
+
+        connection_options = {
           :region => s3_sync_options.region,
           :path_style => s3_sync_options.path_style
-        })
+        }
+
+        if s3_sync_options.aws_access_key_id && s3_sync_options.aws_secret_access_key
+          connection_options.merge!({
+            :aws_access_key_id => s3_sync_options.aws_access_key_id,
+            :aws_secret_access_key => s3_sync_options.aws_secret_access_key
+          })
+        else
+          connection_options.merge!({ use_iam_profile: true })
+        end
+
+        @connection ||= Fog::Storage::AWS.new(connection_options)
       end
 
       def resources

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -70,7 +70,7 @@ module Middleman
             :aws_secret_access_key => s3_sync_options.aws_secret_access_key
           })
         else
-          connection_options.merge!({ use_iam_profile: true })
+          connection_options.merge!({ :use_iam_profile => true })
         end
 
         @connection ||= Fog::Storage::AWS.new(connection_options)


### PR DESCRIPTION
As mentioned in this issue: https://github.com/fredjean/middleman-s3_sync/issues/84#issuecomment-93610098

You don't need to (and must not) specify access keys if you are using EC2 instance with appropriate IAM role. This is especially useful if you are automating middleman builds with something like Jenkins, that is deployed on EC2 (precisely my situation).