### PR TITLE
Add support for explicit specification of content-types for S3 paths/keys.

### DIFF
--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -19,7 +19,8 @@ module Middleman
         :reduced_redundancy_storage,
         :path_style,
         :version_bucket,
-        :verbose
+        :verbose,
+        :content_types
       ]
       attr_accessor *OPTIONS
 
@@ -99,6 +100,10 @@ module Middleman
 
       def version_bucket
         @version_bucket.nil? ? false : @version_bucket
+      end
+
+      def content_types
+        @content_types || {}
       end
 
       # Read config options from an IO stream and set them on `self`. Defaults

--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -205,6 +205,7 @@ module Middleman
       end
 
       def content_type
+        @content_type ||= options.content_types[path]
         @content_type ||= MIME::Types.of(path).first
       end
 


### PR DESCRIPTION
### What
Add support for explicit specification of content-types for S3 paths/keys. Resolves #7.

### Why
The gem currently infers the content-type given the extension and there are many cases where the extension does not or cannot accurately reflect the content-type. An example of this is when the file has no extension but may be text/html, or the file may be a custom file type like `kml` where the content type is `text/xml`.

While this isn't as awesome as automatically pulling the content-type from the sitemap, the sitemap get's generated after all `after_configurations` run and can be tricky. I think this will solve most of the problem cases I've seen people asking about online and can fill the gap until the next version of the gem is released using the new Middleman extension callbacks.

### Usage
During configuration a hash of S3 paths/keys to content-types can be defined. Because it's left up to the user to define there's a great deal of freedom here.

#### Example 1
A user could configure hardcoded paths to content types.
```ruby
activate :s3_sync do |s3_sync|
  ...
  s3_sync.content_types = {
    "sitemap.xml" => "text/xml",
    "data.json" => "application/json",
    "extensionlesspage" => "text/html"
  }
end
```

#### Example 2
If a user is generating dynamic pages they can keep track of the paths and set their content-types to be html.
```ruby
page_content_types = {}

10.times do |page_number|
  path = "page#{page_number}.html"
  page(path, :proxy => "/page.html, :content_type => "text/html")
  page_content_types[path] = "text/html"
end

activate :s3_sync do |s3_sync|
  ...
  s3_sync.content_types = page_content_types
end
```