### PR TITLE
Middleman v4 support + environment

### DIFF
--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -3,7 +3,7 @@ require 'middleman/s3_sync'
 require 'map'
 
 module Middleman
-  class S3SyncExtension < Extension
+  class S3SyncExtension < ::Middleman::Extension
     # Options supported by the extension...
     option :prefix, nil, 'Path prefix of the resource we are looking for on the server.'
     option :http_prefix, nil, 'Path prefix of the resources'
@@ -26,9 +26,6 @@ module Middleman
 
     def initialize(app, options_hash = {}, &block)
       super
-      app.define_hook :after_s3_sync
-      # Temporary workaround for 3.3 and 3.4.
-      app.send :include, ClassMethods
     end
 
     def after_configuration
@@ -94,7 +91,4 @@ module Middleman
       end
     end
   end
-
-  ::Middleman::Extensions.register(:s3_sync, S3SyncExtension)
 end
-

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -25,7 +25,7 @@ module Middleman
       attr_reader   :app
 
       def sync()
-        @app ||= ::Middleman::Application.server.inst
+        @app ||= ::Middleman::Application.new
 
         say_status "Let's see if there's work to be done..."
         unless work_to_be_done?

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -41,11 +41,6 @@ module Middleman
         create_resources
         update_resources
         delete_resources
-
-        app.run_hook :after_s3_sync, ignored: files_to_ignore.map(&:path),
-                                      created: files_to_create.map(&:path),
-                                      updated: files_to_update.map(&:path),
-                                      deleted: files_to_delete.map(&:path)
       end
 
       def bucket

--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -58,7 +58,7 @@ module Middleman
 
       def update!
         local_content { |body|
-          say_status ANSI.blue{"Updating"} + " #{remote_path}#{ gzipped ? ANSI.white {' (gzipped)'} : ''}"
+          say_status "#{ANSI.blue{"Updating"}} #{remote_path}#{ gzipped ? ANSI.white {' (gzipped)'} : ''}"
           s3_resource.merge_attributes(to_h)
           s3_resource.body = body
 
@@ -76,12 +76,12 @@ module Middleman
       end
 
       def destroy!
-        say_status ANSI.red { "Deleting" } + " " + remote_path
+        say_status "#{ANSI.red{"Deleting"}} #{remote_path}"
         bucket.files.destroy remote_path unless options.dry_run
       end
 
       def create!
-        say_status ANSI.green { "Creating" } + " #{remote_path}#{ gzipped ? ANSI.white {' (gzipped)'} : ''}"
+        say_status "#{ANSI.green{"Creating"}} #{remote_path}#{ gzipped ? ANSI.white {' (gzipped)'} : ''}"
         local_content { |body|
           bucket.files.create(to_h.merge(body: body)) unless options.dry_run
         }
@@ -94,7 +94,7 @@ module Middleman
                    elsif directory?
                      :directory
                    end
-          say_status ANSI.yellow {"Ignoring"} + " #{remote_path} #{ reason ? ANSI.white {"(#{reason})" } : "" }"
+          say_status "#{ANSI.yellow{"Ignoring"}} #{remote_path} #{ reason ? ANSI.white {"(#{reason})" } : "" }"
         end
       end
 
@@ -174,7 +174,7 @@ module Middleman
       end
 
       def redirect?
-        full_s3_resource.metadata.has_key?('x-amz-website-redirect-location')
+        full_s3_resource && full_s3_resource.metadata.has_key?('x-amz-website-redirect-location')
       end
 
       def directory?
@@ -232,7 +232,7 @@ module Middleman
       end
 
       def build_dir
-        options.build_dir
+        options.build_dir || 'build'
       end
 
       def options

--- a/lib/middleman/s3_sync/status.rb
+++ b/lib/middleman/s3_sync/status.rb
@@ -4,7 +4,7 @@ module Middleman
   module S3Sync
     module Status
       def say_status(status)
-        puts ANSI.green{:s3_sync.to_s.rjust(12)} + "  #{status}"
+        puts "#{ANSI.green{:s3_sync.to_s.rjust(12)}}  #{status}"
       end
     end
   end

--- a/lib/middleman/s3_sync/version.rb
+++ b/lib/middleman/s3_sync/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module S3Sync
-    VERSION = "3.3.3"
+    VERSION = "4.0.0"
   end
 end

--- a/middleman-s3_sync.gemspec
+++ b/middleman-s3_sync.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'middleman-core', '~> 3.3'
+  gem.add_runtime_dependency 'middleman-core', '>= 3.3.0'
   gem.add_runtime_dependency 'unf'
   gem.add_runtime_dependency 'fog-aws', '>= 0.1.1'
   gem.add_runtime_dependency 'map'


### PR DESCRIPTION
- Adds support for MM v4, in particular the command class is now converted to be a `Thor::Group` as it seems this is what all v4 Cli plugins do.
- Removed duplicate extension registration, which causes en error in v4 `::Middleman::Extensions.register(:s3_sync, S3SyncExtension)`
- Removed usage `:after_s3_sync` hook, as support for hooks was dropped in v4.
- Added support for command line options -e (environment) and -i (instrument logging)
- Fixes a number of small issues I found, including:
   - ANSI.color{ "string" } + "text" caused an error if the ANSI part was nil.
   - `Resouce#redirect?` and `#build_dir` methods had a nil-related errors
- Bumped version to 4.0.0
