### PR TITLE
S3Sync must be the last action in the manipulator chain

### DIFF
--- a/lib/middleman-s3_sync/commands.rb
+++ b/lib/middleman-s3_sync/commands.rb
@@ -1,4 +1,4 @@
-require 'middleman-core/cli'
+require 'middleman-cli'
 
 module Middleman
   module Cli

--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -24,6 +24,9 @@ module Middleman
     option :verbose, false, 'Whether to provide more verbose output'
     option :dry_run, false, 'Whether to perform a dry-run'
 
+    # S3Sync must be the last action in the manipulator chain
+    self.resource_list_manipulator_priority = 9999
+
     def initialize(app, options_hash = {}, &block)
       super
     end

--- a/middleman-s3_sync.gemspec
+++ b/middleman-s3_sync.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency 'middleman-core', '>= 4.0.0.rc.1'
+  gem.add_runtime_dependency 'middleman-cli'
   gem.add_runtime_dependency 'unf'
   gem.add_runtime_dependency 'fog-aws', '>= 0.1.1'
   gem.add_runtime_dependency 'map'

--- a/middleman-s3_sync.gemspec
+++ b/middleman-s3_sync.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'middleman-core', '>= 3.3.0'
+  gem.add_runtime_dependency 'middleman-core', '>= 4.0.0.rc.1'
   gem.add_runtime_dependency 'unf'
   gem.add_runtime_dependency 'fog-aws', '>= 0.1.1'
   gem.add_runtime_dependency 'map'


### PR DESCRIPTION
I had issues where certain manipulators, e.g. I18n, were not being processed in the S3 sync. To remedy this, we must instruct S3 to be the last item in the chain.

This PR bumps the dependency on Middleman to 4.0.0.rc.1, otherwise this feature can't be used. (The assumption here is that since my last PR we are working on v4.0.0 of this plugin, which will only be compatible with MM v4.0.0)