### PR TITLE
Build before deploy + AWS key Thor args

### DIFF
--- a/lib/middleman-s3_sync/commands.rb
+++ b/lib/middleman-s3_sync/commands.rb
@@ -30,6 +30,16 @@ module Middleman
                    type: :boolean,
                    desc: 'Push all local files to the server.'
 
+      class_option :aws_access_key_id,
+                   aliases: '-k',
+                   type: :string,
+                   desc: 'Specify aws_access_key_id, and overrides the configured value.'
+
+      class_option :aws_secret_access_key,
+                   aliases: '-s',
+                   type: :string,
+                   desc: 'Specify aws_secret_access_key, and overrides the configured value.'
+
       class_option :bucket,
                    aliases: '-b',
                    type: :string,
@@ -78,6 +88,8 @@ module Middleman
 
         # Override options based on what was passed on the command line...
         s3_sync_options.force = options[:force] if options[:force]
+        s3_sync_options.aws_access_key_id = options[:aws_access_key_id] if options[:aws_access_key_id]
+        s3_sync_options.aws_secret_access_key = options[:aws_secret_access_key] if options[:aws_secret_access_key]
         s3_sync_options.bucket = options[:bucket] if options[:bucket]
         s3_sync_options.verbose = options[:verbose] if options[:verbose]
         if options[:prefix]

--- a/lib/middleman-s3_sync/commands.rb
+++ b/lib/middleman-s3_sync/commands.rb
@@ -20,6 +20,11 @@ module Middleman
                    default: ENV['MM_ENV'] || ENV['RACK_ENV'] || 'production',
                    desc: 'The environment to deploy.'
 
+      class_option :build,
+                   type: :boolean,
+                   aliases: '-B',
+                   desc: 'Run `middleman build` before the sync step'
+
       class_option :force,
                    aliases: '-f',
                    type: :boolean,
@@ -61,6 +66,8 @@ module Middleman
           ::Middleman::Logger.singleton(verbose, instrument)
         end
 
+        build(options)
+
         s3_sync_options = ::Middleman::S3Sync.s3_sync_options
 
         bucket = s3_sync_options.bucket rescue nil
@@ -80,6 +87,12 @@ module Middleman
         s3_sync_options.dry_run = options[:dry_run] if options[:dry_run]
 
         ::Middleman::S3Sync.sync()
+      end
+
+      def build(options = {})
+        if options[:build]
+          run("middleman build -e #{options[:environment]}") || exit(1)
+        end
       end
     end
 


### PR DESCRIPTION
- Add flag -B which makes middleman build automatically before the sync actual occurs. (-b is already used by bucket)
- Add aws_access_key_id / aws_secret_access_key as Thor args (-k / -s)