### PR TITLE
Custom error document and index suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ activate :s3_sync do |s3_sync|
   s3_sync.encryption                 = false
   s3_sync.prefix                     = ''
   s3_sync.version_bucket             = false
+  s3_sync.error_document             = '404.html'
+  s3_sync.index_suffix               = 'index.html'
 end
 ```
 
@@ -69,6 +71,7 @@ The following defaults apply to the configuration items:
 | encryption                 | ```false```                        |
 | acl                        | ```'public-read'```                |
 | version_bucket             | ```false```                        |
+| index_suffix               | ```index.html```                   |
 
 You do not need to specify the settings that match the defaults. This
 simplify the configuration of the extension:
@@ -302,6 +305,15 @@ instead of the original and the ```Content-Encoding``` and ```Content-Type```
 headers will be set correctly. This will cause Amazon to serve the
 compressed version of the resource. In order for this to work, you need to
 have the `:gzip` extension activated in your `config.rb`.
+
+#### Custom index suffix and error document
+
+You can enable a custom [index suffix](http://docs.aws.amazon.com/AmazonS3/latest/dev/IndexDocumentSupport.html)
+and [error document](http://docs.aws.amazon.com/AmazonS3/latest/dev/CustomErrorDocSupport.html)
+settings. The ```index_suffix``` option tells which file name gets used as
+the index document of a directory (typically, ```index.html```), while
+```error_document``` specifies the document to display for 4xx errors (ie,
+the 404 page).
 
 ## A Debt of Gratitude
 

--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -23,6 +23,8 @@ module Middleman
     option :version_bucket, false, 'Whether to enable versionning on the S3 bucket content'
     option :verbose, false, 'Whether to provide more verbose output'
     option :dry_run, false, 'Whether to perform a dry-run'
+    option :index_suffix, nil, 'Path of S3 directory index document'
+    option :error_document, nil, 'Path of S3 custom error document'
 
     def initialize(app, options_hash = {}, &block)
       super

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -35,6 +35,8 @@ module Middleman
 
         update_bucket_versioning
 
+        update_bucket_website
+
         ignore_resources
         create_resources
         update_resources
@@ -76,6 +78,17 @@ module Middleman
       protected
       def update_bucket_versioning
         connection.put_bucket_versioning(s3_sync_options.bucket, "Enabled") if s3_sync_options.version_bucket
+      end
+
+      def update_bucket_website
+        opts = {}
+        opts[:ErrorDocument] = s3_sync_options.error_document unless s3_sync_options.error_document.nil?
+        opts[:IndexDocument] = s3_sync_options.index_suffix unless s3_sync_options.index_suffix.nil?
+        unless opts.empty?
+          opts[:IndexDocument] ||= 'index.html' # IndexDocument is mandatory in put_bucket_website
+          say_status "Putting bucket website: #{opts.to_json}"
+          connection.put_bucket_website(s3_sync_options.bucket, opts)
+        end
       end
 
       def connection
@@ -188,4 +201,3 @@ module Middleman
     end
   end
 end
-

--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -21,7 +21,9 @@ module Middleman
         :version_bucket,
         :dry_run,
         :verbose,
-        :content_types
+        :content_types,
+        :index_suffix,
+        :error_document
       ]
       attr_accessor *OPTIONS
 


### PR DESCRIPTION
Allows to config a custom error document for the bucket, and to change the default document name for directories indexes (ie, `index.html`).

It doesn't make any change by default - you have to enable it in the config.

It should be cherry-pickeable onto `master`, but haven't tried it there.