### PR TITLE
Improvement to S3 Index / Error docs feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ activate :s3_sync do |s3_sync|
   s3_sync.encryption                 = false
   s3_sync.prefix                     = ''
   s3_sync.version_bucket             = false
+  s3_sync.index_document             = 'index.html'
   s3_sync.error_document             = '404.html'
-  s3_sync.index_suffix               = 'index.html'
 end
 ```
 
@@ -76,7 +76,6 @@ The following defaults apply to the configuration items:
 | encryption                 | ```false```                        |
 | acl                        | ```'public-read'```                |
 | version_bucket             | ```false```                        |
-| index_suffix               | ```index.html```                   |
 
 ## Setting AWS Credentials
 
@@ -336,11 +335,11 @@ headers will be set correctly. This will cause Amazon to serve the
 compressed version of the resource. In order for this to work, you need to
 have the `:gzip` extension activated in your `config.rb`.
 
-#### Custom index suffix and error document
+#### Custom S3 Index and Error Documents
 
-You can enable a custom [index suffix](http://docs.aws.amazon.com/AmazonS3/latest/dev/IndexDocumentSupport.html)
+You can enable a custom [index document](http://docs.aws.amazon.com/AmazonS3/latest/dev/IndexDocumentSupport.html)
 and [error document](http://docs.aws.amazon.com/AmazonS3/latest/dev/CustomErrorDocSupport.html)
-settings. The ```index_suffix``` option tells which file name gets used as
+settings. The ```index_document``` option tells which file name gets used as
 the index document of a directory (typically, ```index.html```), while
 ```error_document``` specifies the document to display for 4xx errors (ie,
 the 404 page).

--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -23,8 +23,8 @@ module Middleman
     option :version_bucket, false, 'Whether to enable versionning on the S3 bucket content'
     option :verbose, false, 'Whether to provide more verbose output'
     option :dry_run, false, 'Whether to perform a dry-run'
-    option :index_suffix, nil, 'Path of S3 directory index document'
-    option :error_document, nil, 'Path of S3 custom error document'
+    option :index_document, nil, 'S3 custom index document path'
+    option :error_document, nil, 'S3 custom error document path'
 
     # S3Sync must be the last action in the manipulator chain
     self.resource_list_manipulator_priority = 9999

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -79,10 +79,14 @@ module Middleman
 
       def update_bucket_website
         opts = {}
-        opts[:ErrorDocument] = s3_sync_options.error_document unless s3_sync_options.error_document.nil?
-        opts[:IndexDocument] = s3_sync_options.index_suffix unless s3_sync_options.index_suffix.nil?
+        opts[:IndexDocument] = s3_sync_options.index_document if s3_sync_options.index_document
+        opts[:ErrorDocument] = s3_sync_options.error_document if s3_sync_options.error_document
+
+        if opts[:ErrorDocument] && !opts[:IndexDocument]
+          raise 'S3 requires `index_document` if `error_document` is specified'
+        end
+
         unless opts.empty?
-          opts[:IndexDocument] ||= 'index.html' # IndexDocument is mandatory in put_bucket_website
           say_status "Putting bucket website: #{opts.to_json}"
           connection.put_bucket_website(s3_sync_options.bucket, opts)
         end

--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -22,7 +22,7 @@ module Middleman
         :dry_run,
         :verbose,
         :content_types,
-        :index_suffix,
+        :index_document,
         :error_document
       ]
       attr_accessor *OPTIONS


### PR DESCRIPTION
- Rename index_suffix to index_document in order to better match S3 naming.

- If error doc but not index doc is specified, raise validation error instead silently defaulting index to 'index.html' (which may overwrite a user's existing setting within S3).