### PR TITLE
Adds try to loading of caching_policy

### DIFF
--- a/lib/middleman/s3_sync/caching_policy.rb
+++ b/lib/middleman/s3_sync/caching_policy.rb
@@ -9,7 +9,7 @@ module Middleman
 
       def caching_policy_for(content_type)
         return default_caching_policy unless content_type
-        caching_policies.fetch(content_type.to_s.split(';').first.strip, caching_policies[:default])
+        caching_policies.fetch(content_type.to_s.split(';').first.try(:strip), caching_policies[:default])
       end
 
       def default_caching_policy


### PR DESCRIPTION
Hi

Not my code - but I just hit the same issue here. Adding a 'try' will fix it.

```
    10:       def caching_policy_for(content_type)
 => 11: 	binding.pry
    12:         caching_policies.fetch(content_type.to_s.split(';').first.strip, caching_policies[:default])
    13:       end

[1] pry(Middleman::S3Sync)> content_type
=> nil
[2] pry(Middleman::S3Sync)> content_type.to_s
=> ""
[3] pry(Middleman::S3Sync)> content_type.to_s.split(';')
=> []
[4] pry(Middleman::S3Sync)> content_type.to_s.split(';').first
=> nil
[5] pry(Middleman::S3Sync)> content_type.to_s.split(';').first.strip
NoMethodError: undefined method `strip' for nil:NilClass
from (pry):10:in `caching_policy_for'
[6] pry(Middleman::S3Sync)> content_type.to_s.split(';').first.try(:strip)
=> nil
[7] pry(Middleman::S3Sync)>
```