### PR TITLE
Add mime-types gem as a runtime dependency

### DIFF
--- a/middleman-s3_sync.gemspec
+++ b/middleman-s3_sync.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'parallel'
   gem.add_runtime_dependency 'ruby-progressbar'
   gem.add_runtime_dependency 'ansi', '~> 1.5.0'
+  gem.add_runtime_dependency 'mime-types', '~> 3.1'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'pry'


### PR DESCRIPTION
As exposed in #123, mime-types is required during sync.

```
    s3_sync  Let's see if there's work to be done...
[fog][WARNING] 'mime-types' missing, please install and try again.
[fog][WARNING] 'mime-types' missing, please install and try again.
[fog][WARNING] 'mime-types' missing, please install and try again.
[fog][WARNING] 'mime-types' missing, please install and try again.
[fog][WARNING] 'mime-types' missing, please install and try again.
[fog][WARNING] 'mime-types' missing, please install and try again.
[fog][WARNING] 'mime-types' missing, please install and try again.
```