### PR TITLE
Docs: updating docs to include principal in IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,13 @@ contained in a bucket named "mysite.com":
   "Statement": [
     {
       "Effect": "Allow",
+      "Principal": "*",
       "Action": "s3:*",
       "Resource": "arn:aws:s3:::mysite.com"
     },
     {
       "Effect": "Allow",
+      "Principal": "*",
       "Action": "s3:*",
       "Resource": "arn:aws:s3:::mysite.com/*"
     }


### PR DESCRIPTION
I got this error when using the example IAM policy from the readme: `Missing required field Principal - undefined`.  Adding `"Principal": "*",` to each statement fixed it for me.
