### PR TITLE
Add option to exclude files from the sync set

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ activate :s3_sync do |s3_sync|
   s3_sync.version_bucket             = false
   s3_sync.index_document             = 'index.html'
   s3_sync.error_document             = '404.html'
+  s3_sync.exclude                    = [/^foo\/bar/]
 end
 ```
 
@@ -71,6 +72,7 @@ The following defaults apply to the configuration items:
 | encryption                 | ```false```                        |
 | acl                        | ```'public-read'```                |
 | version_bucket             | ```false```                        |
+| exclude                    | ```[]```                           |
 
 You do not need to specify the settings that match the defaults. This
 simplify the configuration of the extension:
@@ -313,6 +315,24 @@ settings. The ```index_document``` option tells which file name gets used as
 the index document of a directory (typically, ```index.html```), while
 ```error_document``` specifies the document to display for 4xx errors (ie,
 the 404 page).
+
+You can enable a custom [index document](http://docs.aws.amazon.com/AmazonS3/latest/dev/IndexDocumentSupport.html)
+and [error document](http://docs.aws.amazon.com/AmazonS3/latest/dev/CustomErrorDocSupport.html)
+settings. The ```index_document``` option tells which file name gets used as
+the index document of a directory (typically, ```index.html```), while
+```error_document``` specifies the document to display for 4xx errors (ie,
+the 404 page).
+
+#### Excluding files from the sync
+
+You can set the `exclude` option to an array of regexps that would be used to match agains all the
+resources (local and remote) to decide which files should be synced and which not. The remote path will be used
+when doing the match. For example, had we the following `exclude = [/^docs\//, /file.txt/]` then:
+
+- Local files under `docs/` (or prefixed with `docs/`) won't be uploaded to S3. Also any file that
+had `file.txt` on their remote path won't be uploaded either.
+- Remote files under `docs/` or with `file.txt` on their path won't be considered while doing the sync. This means
+that we could have a `docs/` dir on S3 and not locally and `s3_sync` won't remove the files remotelly.
 
 ## A Debt of Gratitude
 

--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -26,6 +26,7 @@ module Middleman
     option :index_document, nil, 'S3 custom index document path'
     option :error_document, nil, 'S3 custom error document path'
     option :content_types, {}, 'Custom content types'
+    option :exclude, [], "Regexps matching resources to exclude"
 
     def initialize(app, options_hash = {}, &block)
       super

--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -23,7 +23,8 @@ module Middleman
         :verbose,
         :content_types,
         :index_document,
-        :error_document
+        :error_document,
+        :exclude
       ]
       attr_accessor *OPTIONS
 


### PR DESCRIPTION
### Why this change

Because we need a way to exclude files when doing the sync between the local build and S3.

The reason for this is the incoming migration of the documentation on the `marketing-website`. This migration consists in extracting the docs to a separate app which be the one pushing the docs to the same S3 bucket the `marketing-website` uses. This means that we have to exclude the paths modified by the new docs app so that the `s3_sync` doesn't override its files.

#### Related changes

- Update the `s3_sync` config on the marketing website to exclude the affected dirs https://github.com/contentful/marketing-website/pull/727