### PR TITLE
Add endpoint option

### DIFF
--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -9,6 +9,7 @@ module Middleman
     option :http_prefix, nil, 'Path prefix of the resources'
     option :acl, 'public-read', 'ACL for the resources being pushed to S3'
     option :bucket, nil, 'The name of the bucket we are pushing to.'
+    option :endpoint, nil, 'The name of the endpoint to use - useful when using S3 compatible storage'
     option :region, 'us-east-1', 'The name of the AWS region hosting the S3 bucket'
     option :aws_access_key_id, ENV['AWS_ACCESS_KEY_ID'] , 'The AWS access key id'
     option :aws_secret_access_key, ENV['AWS_SECRET_ACCESS_KEY'], 'The AWS secret access key'

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -94,6 +94,7 @@ module Middleman
 
       def connection
         connection_options = {
+          :endpoint => s3_sync_options.endpoint,
           :region => s3_sync_options.region,
           :path_style => s3_sync_options.path_style
         }

--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -6,6 +6,7 @@ module Middleman
         :http_prefix,
         :acl,
         :bucket,
+        :endpoint,
         :region,
         :aws_access_key_id,
         :aws_secret_access_key,


### PR DESCRIPTION
Allow to pass the endpoint option of fog. This is useful when using S3 compatible storage.