### PR TITLE
Ignoring of remote and local files

### DIFF
--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -27,6 +27,7 @@ module Middleman
     option :index_document, nil, 'S3 custom index document path'
     option :error_document, nil, 'S3 custom error document path'
     option :content_types, {}, 'Custom content types'
+    option :ignore_paths, [], 'Paths that should be ignored during sync, strings or regex are allowed'
 
     expose_to_config :s3_sync_options, :default_caching_policy, :caching_policy
 

--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -23,6 +23,7 @@ module Middleman
         :dry_run,
         :verbose,
         :content_types,
+        :ignore_paths,
         :index_document,
         :error_document
       ]
@@ -66,6 +67,10 @@ module Middleman
 
       def path_style
         (@path_style.nil? ? true : @path_style)
+      end
+
+      def ignore_paths
+        @ignore_paths.nil? ? [] : @ignore_paths
       end
 
       def prefix=(prefix)

--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -132,7 +132,9 @@ module Middleman
       end
 
       def status
-        @status ||= if directory?
+        @status ||= if shunned?
+                      :ignored
+                    elsif directory?
                       if remote?
                         :deleted
                       else
@@ -192,6 +194,10 @@ module Middleman
         else
           true
         end
+      end
+
+      def shunned?
+        !!path[Regexp.union(options.ignore_paths)]
       end
 
       def remote_redirect_url

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -154,4 +154,46 @@ describe Middleman::S3Sync::Resource do
       its(:remote_path) { is_expected.to eq 'path/to/resource.html' }
     end
   end
+
+  context 'An ignored resource' do
+    context "that is local" do
+
+      subject(:resource) { Middleman::S3Sync::Resource.new(mm_resource, nil) }
+
+      let(:mm_resource) {
+        double(
+          destination_path: 'ignored/path/to/resource.html'
+        )
+      }
+
+      before do
+        allow(File).to receive(:exist?).with('build/ignored/path/to/resource.html').and_return(true)
+        options.ignore_paths = [/^ignored/]
+      end
+
+      its(:status) { is_expected.to eq :ignored }
+    end
+
+    context "that is remote" do
+
+      subject(:resource) { Middleman::S3Sync::Resource.new(nil, remote) }
+
+      let(:remote) {
+        double(
+          key: 'ignored/path/to/resource.html',
+          metadata: {}
+        )
+      }
+
+      before do
+        resource.full_s3_resource = remote
+        allow(remote).to receive(:key).and_return('ignored/path/to/resource.html')
+        options.ignore_paths = [/^ignored/]
+      end
+
+      its(:status) { is_expected.to eq :ignored }
+    end
+
+  end
+
 end


### PR DESCRIPTION
add ability to create an array of ignored path strings and regex that is applied to all resources during sync. Any matches are ignored both remotely and locally and wont be uploaded from local or remotely deleted.

Happy to make any changes you want, just let me know!