### PR TITLE
Add support for AWS_SESSION_TOKEN and AWS_SECURITY_TOKEN

### DIFF
--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -13,6 +13,7 @@ module Middleman
     option :region, 'us-east-1', 'The name of the AWS region hosting the S3 bucket'
     option :aws_access_key_id, ENV['AWS_ACCESS_KEY_ID'] , 'The AWS access key id'
     option :aws_secret_access_key, ENV['AWS_SECRET_ACCESS_KEY'], 'The AWS secret access key'
+    option :aws_session_token, ENV['AWS_SESSION_TOKEN'] || ENV['AWS_SECURITY_TOKEN'], 'The AWS session token (for assuming roles)'
     option :after_build, false, 'Whether to synchronize right after the build'
     option :build_dir, nil, 'Where the built site is stored'
     option :delete, true, 'Whether to delete resources that do not have a local equivalent'
@@ -41,6 +42,7 @@ module Middleman
       read_config
       options.aws_access_key_id ||= ENV['AWS_ACCESS_KEY_ID']
       options.aws_secret_access_key ||= ENV['AWS_SECRET_ACCESS_KEY']
+      options.aws_session_token ||= ENV['AWS_SESSION_TOKEN'] || ENV['AWS_SECURITY_TOKEN']
       options.bucket ||= ENV['AWS_BUCKET']
       options.http_prefix = app.http_prefix if app.respond_to? :http_prefix
       options.build_dir ||= app.build_dir if app.respond_to? :build_dir

--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -106,6 +106,11 @@ module Middleman
             :aws_access_key_id => s3_sync_options.aws_access_key_id,
             :aws_secret_access_key => s3_sync_options.aws_secret_access_key
           })
+
+          # If using a assumed role
+          connection_options.merge!({
+            :aws_session_token => s3_sync_options.aws_session_token
+          }) if s3_sync_options.aws_session_token
         else
           connection_options.merge!({ :use_iam_profile => true })
         end


### PR DESCRIPTION
These environmental variables are used when you assume an AWS role; https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html