### PR TITLE
Optimize creation of resources

### DIFF
--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -59,7 +59,12 @@ module Middleman
     end
 
     def manipulate_resource_list(mm_resources)
-      ::Middleman::S3Sync.mm_resources = mm_resources
+      ::Middleman::S3Sync.mm_resources = mm_resources.each_with_object([]) do |resource, list|
+        next if resource.ignored?
+
+        list << resource
+        list << resource.target_resource if resource.respond_to?(:target_resource)
+      end
     end
 
     def s3_sync_options

--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -58,13 +58,15 @@ module Middleman
       ::Middleman::S3Sync.sync() if options.after_build
     end
 
-    def manipulate_resource_list(mm_resources)
-      ::Middleman::S3Sync.mm_resources = mm_resources.each_with_object([]) do |resource, list|
+    def manipulate_resource_list(resources)
+      ::Middleman::S3Sync.mm_resources = resources.each_with_object([]) do |resource, list|
         next if resource.ignored?
 
         list << resource
         list << resource.target_resource if resource.respond_to?(:target_resource)
       end
+
+      resources
     end
 
     def s3_sync_options


### PR DESCRIPTION
Hi,
In my app, I have a huge amount of ignored resources, sometimes a couple of thousands. While this is a corner case and this patch won't be useful for everyone, I think that creation of only needed `S3Sync::Resource` objects is generally a good idea.