### PR TITLE
Fix content_types feature

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -71,7 +71,7 @@ module Middleman
       end
 
       def content_types
-        @content_types || {}
+        s3_sync_options.content_types
       end
 
       protected


### PR DESCRIPTION
`content_types` setting is being ignored at the moment `@content_types` instance variable was never initialised. This PR connects the setting to the configuration object.