### PR TITLE
Ruby 3.2 compat

### DIFF
--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -77,7 +77,7 @@ module Middleman
         config_file_path = File.join(root_path, ".s3_sync")
 
         # skip if config file does not exist
-        return unless File.exists?(config_file_path)
+        return unless File.exist?(config_file_path)
 
         io = File.open(config_file_path, "r")
       end

--- a/middleman-s3_sync.gemspec
+++ b/middleman-s3_sync.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'timerizer'
   gem.add_development_dependency 'travis'
   gem.add_development_dependency 'travis-lint'
+  gem.add_development_dependency 'webrick'
 end


### PR DESCRIPTION
Heya @fredjean, hope this gets to you!

This brings Ruby 3.2 compatibility to the s3_sync plugin for middleman

I'd be keen to get someone else to test this branch too