### PR TITLE
use newer Fog::AWS::Storage

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -106,7 +106,7 @@ module Middleman
           connection_options.merge!({ :use_iam_profile => true })
         end
 
-        @connection ||= Fog::Storage::AWS.new(connection_options)
+        @connection ||= Fog::AWS::Storage.new(connection_options)
       end
 
       def remote_resource_for_path(path)


### PR DESCRIPTION
`Fog::Storage::AWS` is deprecated

Fixes #156 