### PR TITLE
Correct SDK side of index_document and error_document

### DIFF
--- a/lib/middleman/s3_sync.rb
+++ b/lib/middleman/s3_sync.rb
@@ -107,10 +107,10 @@ module Middleman
 
       def update_bucket_website
         opts = {}
-        opts[:IndexDocument] = s3_sync_options.index_document if s3_sync_options.index_document
-        opts[:ErrorDocument] = s3_sync_options.error_document if s3_sync_options.error_document
+        opts[:index_document] = { "suffix": s3_sync_options.index_document } if s3_sync_options.index_document
+        opts[:error_document] = { "key": s3_sync_options.error_document } if s3_sync_options.error_document
 
-        if opts[:ErrorDocument] && !opts[:IndexDocument]
+        if opts[:error_document] && !opts[:index_document]
           raise 'S3 requires `index_document` if `error_document` is specified'
         end
 


### PR DESCRIPTION
I feel like I'm missing something here, but I couldn't get the current code to work at all out of the box. [The documentation](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html) says nothing about `:IndexDocument` or `:ErrorDocument`, and the code throws errors:

```rb
/usr/local/bundle/gems/aws-sdk-core-3.232.0/lib/aws-sdk-core/param_validator.rb:35:in `validate!': parameter validator found 2 errors: (ArgumentError)
  - unexpected value at params[:website_configuration][:IndexDocument]
  - unexpected value at params[:website_configuration][:ErrorDocument]
```

And if you don't pass an object:

```rb
/usr/local/bundle/gems/aws-sdk-core-3.232.0/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `convert_jsonvalue': undefined method `key?' for "error/index.html":String (NoMethodError)

          return if params.nil? || !params.key?(m)
                                          ^^^^^
```

It looks like `:IndexDocument` is from `fog-aws`, but the change to remove that was back in February and there are plenty of commits since then.