### PR TITLE
Release v4.6.5: performance and stability improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,18 @@
 
 The gem that tries really hard not to push files to S3.
 
+## v4.6.5
+- Performance and stability improvements
+  - Thread-safe invalidation path tracking (use Set + mutex) when running in parallel
+  - Cache CloudFront client (with reset hook for tests)
+  - Single-pass resource categorization (reduce multiple iterations over resources)
+  - Batch S3 deletes via delete_objects (up to 1000 keys/request)
+  - Stream file uploads to reduce memory; compute MD5s in a single read when possible
+  - Optimize CloudFront path deduplication to O(n × path_depth)
+  - CLI/extension: support option writers (e.g., verbose=, dry_run=) to fix NoMethodError
+- Tests: add coverage for CloudFront, batch delete, and streaming uploads
+- No breaking changes; default behavior preserved
+
 ## v4.6.4
 * Remove map gem dependency and replace with native Ruby implementation
 * Add IndifferentHash class to provide string/symbol indifferent access without external dependencies

--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -87,16 +87,30 @@ module Middleman
       true
     end
 
-    # Delegate option readers to the options object
+    # Delegate option readers and writers to the options object
     def method_missing(method, *args, &block)
-      if options.respond_to?(method)
-        options.send(method, *args, &block)
-      else
-        super
+      method_str = method.to_s
+      
+      # Handle setter methods (e.g., verbose=)
+      if method_str.end_with?('=')
+        option_name = method_str.chomp('=').to_sym
+        if options.respond_to?(option_name)
+          options[option_name] = args.first
+          return args.first
+        end
+      elsif options.respond_to?(method)
+        return options.send(method, *args, &block)
       end
+      
+      super
     end
 
     def respond_to_missing?(method, include_private = false)
+      method_str = method.to_s
+      if method_str.end_with?('=')
+        option_name = method_str.chomp('=').to_sym
+        return options.respond_to?(option_name)
+      end
       options.respond_to?(method) || super
     end
 

--- a/lib/middleman/s3_sync/version.rb
+++ b/lib/middleman/s3_sync/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module S3Sync
-    VERSION = "4.6.4"
+    VERSION = "4.6.5"
   end
 end

--- a/spec/cloudfront_spec.rb
+++ b/spec/cloudfront_spec.rb
@@ -27,6 +27,8 @@ describe Middleman::S3Sync::CloudFront do
 
   before do
     allow(described_class).to receive(:say_status)
+    # Reset cached CloudFront client between tests to prevent double leakage
+    described_class.send(:reset_cloudfront_client!)
   end
 
   describe '.invalidate' do


### PR DESCRIPTION
Summary
- Thread-safe invalidation path tracking (Set + mutex) under parallel operations
- Cache CloudFront client; add reset_cloudfront_client! for tests
- Single-pass resource categorization (reduce 4 iterations to 1)
- Batch S3 deletes via delete_objects (up to 1000 keys/request)
- Stream uploads; compute MD5s in a single read when not gzipped
- Faster CloudFront redundant-path pruning (O(n × path_depth))
- CLI/extension: delegate option writers (e.g., verbose=, dry_run=) to fix NoMethodError
- Tests: coverage for batch delete, streaming uploads, and CloudFront

Performance
- s3_sync (fredjean.net): 7.72s (new) vs 7.74s (old) averaged over 2 runs; identical under light updates, with gains expected on large invalidations/deletes.

Changelog
- Bump to 4.6.5

Co-Authored-By: Warp <agent@warp.dev>