### PR TITLE
Add immutable directive and prefer max-age over Expires

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,20 @@
 
 The gem that tries really hard not to push files to S3.
 
+## v4.8.0
+- Add `immutable` directive to caching policies. Pair with a long `max_age` on
+  fingerprinted assets (e.g. those produced by Middleman's `asset_hash`
+  extension) to tell browsers they never need to revalidate:
+  `caching_policy 'text/css', max_age: 1.year, public: true, immutable: true`.
+- Prefer `Cache-Control: max-age` over the `Expires` header. When a policy sets
+  `max_age:`, the `Expires` header is now suppressed even if `expires:` is also
+  set. Per RFC 7234 §5.3, `max-age` overrides `Expires` for HTTP/1.1 caches, so
+  emitting both adds no information and forces a metadata update on every build
+  as the `expires:` timestamp drifts forward. Existing configs that rely solely
+  on `expires:` (without `max_age:`) continue to work unchanged.
+- Resource uploads no longer include empty `cache_control` or `expires` keys
+  when the caching policy yields `nil` for them.
+
 ## v4.6.5
 - Performance and stability improvements
   - Thread-safe invalidation path tracking (use Set + mutex) when running in parallel

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,10 @@ The gem that tries really hard not to push files to S3.
   on `expires:` (without `max_age:`) continue to work unchanged.
 - Resource uploads no longer include empty `cache_control` or `expires` keys
   when the caching policy yields `nil` for them.
+- Drop `timerizer` development dependency. Its monkey-patch of `Time.new` was
+  incompatible with Ruby 3.1.7's keyword-argument changes and crashed RSpec at
+  startup on the 3.1 CI matrix. The three test usages were replaced with plain
+  `Time` literals.
 
 ## v4.6.5
 - Performance and stability improvements

--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,42 @@ The gem that tries really hard not to push files to S3.
   startup on the 3.1 CI matrix. The three test usages were replaced with plain
   `Time` literals.
 
+## v4.7.0
+- Add `after_s3_sync` callback hook that runs after sync completes (#138).
+  Accepts a lambda/proc — optionally receiving a results hash with `created`,
+  `updated`, `deleted` counts and invalidation paths — or a symbol referencing
+  a method on the Middleman app. Zero-arg callbacks work without modification
+  via arity detection. Callback failures are logged but do not abort the sync.
+- Add `scan_build_dir` option (default: `false`) to sync files in the build
+  directory that aren't in the Middleman sitemap (#108, #137). Useful for
+  output from `after_build` callbacks, image optimizers, or anything placed
+  in `build/` outside the sitemap.
+- Add `routing_rules` option to configure S3 website routing rules at sync
+  time, so deployments don't overwrite manually-configured rules (#142).
+  Supports `condition.key_prefix_equals`,
+  `condition.http_error_code_returned_equals`, and the
+  `redirect.{host_name, http_redirect_code, protocol, replace_key_prefix_with,
+  replace_key_with}` keys. Requires `index_document` to also be set.
+- Improve content type detection with a `mime-types` fallback for files
+  Middleman doesn't classify (e.g. orphan files, WebP, woff2). The
+  `content_types` option is now checked first, and unknown extensions default
+  to `application/octet-stream`. Bumped `mime-types` constraint to `~> 3.4`.
+  (#161)
+- Fix sitemap population for build-mode extensions (#116, #128). The sync
+  now calls `ensure_resource_list_updated!` so extensions like blog and
+  asset_hash populate the sitemap, and always runs in `:build` mode so
+  `configure :build` blocks are active. Files emitted by `after_build`
+  callbacks still aren't visible to the sitemap — use `scan_build_dir` for
+  those.
+- Fix `Resource#redirect?` to return `true`/`false` instead of a truthy URL
+  string (#143). The status logic was already correct; this just normalizes
+  the boolean contract.
+- Tighten gemspec dependency bounds and require Ruby `>= 3.0` (#167).
+  Pessimistic constraints on all runtime and development deps to resolve the
+  open-ended-dependency warnings on `gem build`.
+- Add GitHub Actions CI matrix (Ruby 3.1, 3.2, 3.3, 3.4) and an automated
+  RubyGems release workflow that publishes on `v*` tags (#169).
+
 ## v4.6.5
 - Performance and stability improvements
   - Thread-safe invalidation path tracking (use Set + mutex) when running in parallel

--- a/README.md
+++ b/README.md
@@ -546,6 +546,21 @@ The following keys can be set:
 | `no_store`         | boolean | `no-store`         | Instructs caches not to keep a copy of the representation under any conditions.                                                        |
 | `must_revalidate`  | boolean | `must-revalidate`  | Tells the caches that they must obey any freshness information you give them about a representation.                                   |
 | `proxy_revalidate` | boolean | `proxy-revalidate` | Similar as `must-revalidate`, but only for proxies.                                                                                    |
+| `immutable`        | boolean | `immutable`        | Tells browsers the response body will never change for this URL, so they should not revalidate even on a user-initiated reload. Pair with a long `max_age` for content-addressed (fingerprinted) assets. |
+
+#### Hashed Assets
+
+If you use Middleman's `asset_hash` extension, fingerprinted asset URLs
+are content-addressed and never need to be revalidated. Combining a
+long `max_age` with `immutable` is the strongest browser cache hint
+you can give:
+
+```ruby
+caching_policy 'text/css',               max_age: 1.year, public: true, immutable: true
+caching_policy 'application/javascript', max_age: 1.year, public: true, immutable: true
+caching_policy 'image/png',              max_age: 1.year, public: true, immutable: true
+caching_policy 'image/jpeg',             max_age: 1.year, public: true, immutable: true
+```
 
 #### Setting `Expires` Header
 
@@ -554,8 +569,11 @@ You can pass the `expires` key to the `caching_policy` and
 header on a results. You will need to pass it a Time object indicating
 when the resource is set to expire.
 
-> Note that the `Cache-Control` header will take precedence over the
-> `Expires` header if both are present.
+> Note that the `Cache-Control` header takes precedence over `Expires`
+> for HTTP/1.1 caches (RFC 7234 §5.3). For that reason, when a policy
+> sets `max_age:`, the `Expires` header is suppressed entirely — even
+> if `expires:` is also set. This avoids redundant metadata churn from
+> the `expires:` timestamp drifting forward on every build.
 
 #### A Note About Browser Caching
 

--- a/lib/middleman/s3_sync/caching_policy.rb
+++ b/lib/middleman/s3_sync/caching_policy.rb
@@ -38,6 +38,7 @@ module Middleman
         policy << "no-store" if policies.fetch(:no_store, false)
         policy << "must-revalidate" if policies.fetch(:must_revalidate, false)
         policy << "proxy-revalidate" if policies.fetch(:proxy_revalidate, false)
+        policy << "immutable" if policies.fetch(:immutable, false)
         if policy.empty?
           nil
         else
@@ -49,7 +50,12 @@ module Middleman
         cache_control
       end
 
+      # Returns an RFC 1123 date for the Expires header.
+      # When :max_age is set we suppress Expires entirely: per RFC 7234 §5.3
+      # max-age takes precedence over Expires for HTTP/1.1 caches, so emitting
+      # both adds no information and forces a metadata update on every build.
       def expires
+        return nil if policies.has_key?(:max_age)
         if expiration = policies.fetch(:expires, nil)
           CGI.rfc1123_date(expiration)
         end

--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -64,8 +64,8 @@ module Middleman
         attributes[:acl] = options.acl if options.acl_enabled?
 
         if caching_policy
-          attributes[:cache_control] = caching_policy.cache_control
-          attributes[:expires] = caching_policy.expires
+          attributes[:cache_control] = caching_policy.cache_control if caching_policy.cache_control
+          attributes[:expires] = caching_policy.expires if caching_policy.expires
         end
 
         if options.prefer_gzip && gzipped
@@ -382,8 +382,8 @@ module Middleman
 
         # Add cache control and expires if present
         if caching_policy
-          upload_options[:cache_control] = caching_policy.cache_control
-          upload_options[:expires] = caching_policy.expires
+          upload_options[:cache_control] = caching_policy.cache_control if caching_policy.cache_control
+          upload_options[:expires] = caching_policy.expires if caching_policy.expires
         end
 
         # Add storage class if needed

--- a/lib/middleman/s3_sync/version.rb
+++ b/lib/middleman/s3_sync/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module S3Sync
-    VERSION = "4.7.0"
+    VERSION = "4.8.0"
   end
 end

--- a/middleman-s3_sync.gemspec
+++ b/middleman-s3_sync.gemspec
@@ -39,6 +39,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-support', '~> 3.12'
   gem.add_development_dependency 'rspec-its', '~> 2.0'
   gem.add_development_dependency 'rspec-mocks', '~> 3.12'
-  gem.add_development_dependency 'timerizer', '~> 0.3'
   gem.add_development_dependency 'webrick', '~> 1.8'
 end

--- a/spec/aws_sdk_parameters_spec.rb
+++ b/spec/aws_sdk_parameters_spec.rb
@@ -479,6 +479,48 @@ describe 'AWS SDK Parameter Validation' do
       end
     end
 
+    context 'when a caching policy with only max_age is in effect' do
+      before do
+        policy = Middleman::S3Sync::BrowserCachePolicy.new(max_age: 31536000, public: true, immutable: true)
+        allow(Middleman::S3Sync).to receive(:caching_policy_for).and_return(policy)
+      end
+
+      it 'sets cache_control but omits expires' do
+        attributes = resource.to_h
+
+        expect(attributes[:cache_control]).to eq('max-age=31536000, public, immutable')
+        expect(attributes).not_to have_key(:expires)
+      end
+    end
+
+    context 'when a caching policy with only expires is in effect' do
+      before do
+        policy = Middleman::S3Sync::BrowserCachePolicy.new(expires: Time.utc(2030, 1, 1))
+        allow(Middleman::S3Sync).to receive(:caching_policy_for).and_return(policy)
+      end
+
+      it 'sets expires but omits cache_control' do
+        attributes = resource.to_h
+
+        expect(attributes[:expires]).to eq(CGI.rfc1123_date(Time.utc(2030, 1, 1)))
+        expect(attributes).not_to have_key(:cache_control)
+      end
+    end
+
+    context 'when a caching policy sets both max_age and expires' do
+      before do
+        policy = Middleman::S3Sync::BrowserCachePolicy.new(max_age: 300, expires: Time.utc(2030, 1, 1))
+        allow(Middleman::S3Sync).to receive(:caching_policy_for).and_return(policy)
+      end
+
+      it 'emits cache_control and suppresses the redundant expires' do
+        attributes = resource.to_h
+
+        expect(attributes[:cache_control]).to eq('max-age=300')
+        expect(attributes).not_to have_key(:expires)
+      end
+    end
+
     context 'when resource has a redirect' do
       let(:mm_resource) do
         double(

--- a/spec/caching_policy_spec.rb
+++ b/spec/caching_policy_spec.rb
@@ -17,6 +17,7 @@ describe Middleman::S3Sync::BrowserCachePolicy do
       expect(policy.to_s).to_not match /no-store/
       expect(policy.to_s).to_not match /must-revalidate/
       expect(policy.to_s).to_not match /proxy-revalidate/
+      expect(policy.to_s).to_not match /immutable/
       expect(policy.expires).to eq nil
     end
 
@@ -62,6 +63,19 @@ describe Middleman::S3Sync::BrowserCachePolicy do
       its(:to_s) { is_expected.to match /proxy-revalidate/ }
     end
 
+    context "setting the immutable flag" do
+      let(:options) { { immutable: true } }
+      its(:to_s) { is_expected.to match /immutable/ }
+    end
+
+    context "combining max_age, public, and immutable for hashed assets" do
+      let(:options) { { max_age: 31536000, public: true, immutable: true } }
+
+      it "emits the directives in policy order" do
+        expect(policy.to_s).to eq "max-age=31536000, public, immutable"
+      end
+    end
+
     context "divide caching policiies with a comma and a space" do
       let(:options) { { :max_age => 300, :public => true } }
 
@@ -77,6 +91,16 @@ describe Middleman::S3Sync::BrowserCachePolicy do
       let(:options) { { expires: 1.years.from_now } }
 
       its(:expires) { is_expected.to eq CGI.rfc1123_date(1.year.from_now )}
+    end
+
+    context "max_age suppresses the Expires header" do
+      let(:options) { { max_age: 300, expires: 1.year.from_now } }
+
+      it "still emits max-age in cache_control" do
+        expect(policy.to_s).to match /max-age=300/
+      end
+
+      its(:expires) { is_expected.to be_nil }
     end
   end
 end

--- a/spec/caching_policy_spec.rb
+++ b/spec/caching_policy_spec.rb
@@ -88,13 +88,14 @@ describe Middleman::S3Sync::BrowserCachePolicy do
     end
 
     context "set the expiration date" do
-      let(:options) { { expires: 1.years.from_now } }
+      let(:expires_at) { Time.utc(2030, 1, 1) }
+      let(:options) { { expires: expires_at } }
 
-      its(:expires) { is_expected.to eq CGI.rfc1123_date(1.year.from_now )}
+      its(:expires) { is_expected.to eq CGI.rfc1123_date(expires_at) }
     end
 
     context "max_age suppresses the Expires header" do
-      let(:options) { { max_age: 300, expires: 1.year.from_now } }
+      let(:options) { { max_age: 300, expires: Time.utc(2030, 1, 1) } }
 
       it "still emits max-age in cache_control" do
         expect(policy.to_s).to match /max-age=300/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'middleman-s3_sync'
-require 'timerizer'
 require 'rspec/its'
 require 'rspec/support'
 require 'digest/md5'


### PR DESCRIPTION
## Summary
- Adds `immutable` to `BrowserCachePolicy` so fingerprinted assets (e.g., from Middleman's `asset_hash`) can be cached with `Cache-Control: public, max-age=31536000, immutable` and skip revalidation entirely.
- Suppresses the `Expires` header when a policy sets `max_age:`. Per RFC 7234 §5.3, `max-age` takes precedence over `Expires` for HTTP/1.1 caches, so emitting both adds no information and forces a metadata update on every build as the `expires:` timestamp drifts forward. Configs that use only `expires:` continue to work unchanged.
- `Resource#to_h` and `#build_upload_options_for_stream` no longer include empty `cache_control` / `expires` keys when the caching policy yields `nil` for them.
- Bumps version to 4.8.0.

## Test plan
- [x] `bundle exec rspec` — 239 examples, 0 failures
- [x] New `caching_policy_spec` cases: `immutable` flag, combined `max_age + public + immutable`, `max_age` suppresses `Expires`
- [x] New `aws_sdk_parameters_spec` cases for `to_h`: max_age-only sets `cache_control` and omits `expires`; expires-only sets `expires` and omits `cache_control`; both sets `cache_control` and suppresses `expires`
- [ ] Manual smoke test against a real S3 bucket / CloudFront distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)